### PR TITLE
Change to new challenge URLs

### DIFF
--- a/src/authentication.js
+++ b/src/authentication.js
@@ -86,7 +86,7 @@ export class AuthProvider {
     )[0];
     const xsrfToken = xsrfCookie.split("=")[1].split(";")[0];
 
-    await fetch(`${issuerUrl}/challenge/username`, {
+    await fetch(`${issuerUrl}/challenges/username`, {
       method: "post",
       body: JSON.stringify({
         authCode,
@@ -101,7 +101,7 @@ export class AuthProvider {
       }
     }).then(this.validate);
 
-    const authCookies = await fetch(`${issuerUrl}/challenge/password`, {
+    const authCookies = await fetch(`${issuerUrl}/challenges/password`, {
       method: "post",
       body: JSON.stringify({
         authCode,


### PR DESCRIPTION
It seems a couple of days ago the challenge URLs were changed. This PR addresses this (they simply got renamed from `/challenge` to `/challenges`.

It works for me when using the latest release (2.0.0-alpha.12) of magister.js and then manually changing `challenge` to `challenges`. I wanted to submit a PR there with the rename, but noticed that since the last release, the authentication was moved to (replaced by) this library, so now I created my PR here.

When trying to get everything working with magister.js master branch and this library I ran into some issues:
* The auth code was not passed along and magister-openid introduced a breaking change in 0.1.4; I've solved this with this PR: https://github.com/simplyGits/MagisterJS/pull/150
* The challenge URLs were not correct (that's THIS PR)
* Finally, it failed with `TypeError: client_secret_basic client authentication method requires a client_secret` in `getTokenSet()`

I haven't been able yet to solve this last error, but at least this PR gets it a few steps further down the authentication flow. I'll put the error in a separate issue. Please note I did not have this error when changing the challenge URL manually in an older version of magister.js.