### PR TITLE
Fix for 'invalid scope' during the Magister authentication flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 > OpenID authentication wrapper for the Magister digital school system
 ### Note this package is no longer actively maintained, use at your own risk.
 
+
 This package provides a simple and spec compliant API for requesting, refreshing and managing authentication tokens
 
 Simple authentication flow:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="https://img.shields.io/librariesio/github/idiidk/magister-openid?style=for-the-badge" />
 
 > OpenID authentication wrapper for the Magister digital school system
-
+### Note this package is no longer actively maintained, use at your own risk.
 
 This package provides a simple and spec compliant API for requesting, refreshing and managing authentication tokens
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 <img src="https://img.shields.io/librariesio/github/idiidk/magister-openid?style=for-the-badge" />
 
 > OpenID authentication wrapper for the Magister digital school system
-### Note this package is no longer actively maintained, use at your own risk.
 
 
 This package provides a simple and spec compliant API for requesting, refreshing and managing authentication tokens

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -119,7 +119,7 @@ var AuthProvider = /*#__PURE__*/function () {
                 });
                 this.client[_openidClient.custom.clock_tolerance] = 5;
                 authUrl = this.client.authorizationUrl({
-                  scope: issuer.scopes_supported.join(" "),
+                  scope: "openid profile offline_access",
                   code_challenge: codeChallenge,
                   code_challenge_method: "S256",
                   acr_values: "tenant:".concat(this.tenant),

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.7",
   "description": "OpenID authentication wrapper for the Magister digital school system",
   "main": "lib/manager.js",
-  "repository": "https://github.com/Jeroen2006/magister-openid.git",
-  "homepage": "https://github.com/Jeroen2006/magister-openid#readme",
+  "repository": "https://github.com/idiidk/magister-openid.git",
+  "homepage": "https://github.com/idiidk/magister-openid#readme",
   "bugs": {
-    "url": "https://github.com/Jeroen2006/magister-openid/issues"
+    "url": "https://github.com/idiidk/magister-openid/issues"
   },
   "author": "idiidk",
   "license": "LGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "magister-openid",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "OpenID authentication wrapper for the Magister digital school system",
   "main": "lib/manager.js",
-  "repository": "https://github.com/idiidk/magister-openid.git",
-  "homepage": "https://github.com/idiidk/magister-openid#readme",
+  "repository": "https://github.com/Jeroen2006/magister-openid.git",
+  "homepage": "https://github.com/Jeroen2006/magister-openid#readme",
   "bugs": {
-    "url": "https://github.com/idiidk/magister-openid/issues"
+    "url": "https://github.com/Jeroen2006/magister-openid/issues"
   },
   "author": "idiidk",
   "license": "LGPL-3.0",

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -56,7 +56,7 @@ export class AuthProvider {
     this.client[custom.clock_tolerance] = 5;
 
     const authUrl = this.client.authorizationUrl({
-      scope: issuer.scopes_supported.join(" "),
+      scope: "openid profile offline_access",
       code_challenge: codeChallenge,
       code_challenge_method: "S256",
       acr_values: `tenant:${this.tenant}`,


### PR DESCRIPTION
It seems a few days ago a couple of scopes were changed. This PR should fix this by using pre-defined scopes instead of fetching 'em from `https://accounts.magister.net/.well-known/openid-configuration`.

I also bumped the version number from `0.1.6` to `0.1.7`.