### PR TITLE
fix(auth): Adapt to new Magister authentication flow

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -1,27 +1,19 @@
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.AuthProvider = void 0;
-
 var _regenerator = _interopRequireDefault(require("@babel/runtime/regenerator"));
-
+var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers/toConsumableArray"));
 var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
 var _nodeFetch = _interopRequireDefault(require("node-fetch"));
-
 var _openidClient = require("openid-client");
-
 var _common = require("./utils/common");
-
-var AuthProvider = /*#__PURE__*/function () {
+var AuthProvider = exports.AuthProvider = /*#__PURE__*/function () {
   function AuthProvider(tenant) {
     (0, _classCallCheck2["default"])(this, AuthProvider);
     this.tenant = tenant;
@@ -30,45 +22,35 @@ var AuthProvider = /*#__PURE__*/function () {
     this.state = _openidClient.generators.state();
     this.nonce = _openidClient.generators.nonce();
   }
-
-  (0, _createClass2["default"])(AuthProvider, [{
+  return (0, _createClass2["default"])(AuthProvider, [{
     key: "validate",
     value: function () {
-      var _validate = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee(response) {
+      var _validate = (0, _asyncToGenerator2["default"])(/*#__PURE__*/_regenerator["default"].mark(function _callee(response) {
         var code, data;
-        return _regenerator["default"].wrap(function _callee$(_context) {
-          while (1) {
-            switch (_context.prev = _context.next) {
-              case 0:
-                code = response.status;
-
-                if (!(code === 200)) {
-                  _context.next = 5;
-                  break;
-                }
-
-                return _context.abrupt("return");
-
-              case 5:
-                _context.next = 7;
-                return response.json();
-
-              case 7:
-                data = _context.sent;
-                throw new Error(data.error || code);
-
-              case 9:
-              case "end":
-                return _context.stop();
-            }
+        return _regenerator["default"].wrap(function (_context) {
+          while (1) switch (_context.prev = _context.next) {
+            case 0:
+              code = response.status;
+              if (!(code === 200)) {
+                _context.next = 1;
+                break;
+              }
+              return _context.abrupt("return");
+            case 1:
+              _context.next = 2;
+              return response.json();
+            case 2:
+              data = _context.sent;
+              throw new Error(data.error || code);
+            case 3:
+            case "end":
+              return _context.stop();
           }
         }, _callee);
       }));
-
       function validate(_x) {
         return _validate.apply(this, arguments);
       }
-
       return validate;
     }()
   }, {
@@ -94,144 +76,126 @@ var AuthProvider = /*#__PURE__*/function () {
   }, {
     key: "getCode",
     value: function () {
-      var _getCode = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee3(username, password, authCode) {
+      var _getCode = (0, _asyncToGenerator2["default"])(/*#__PURE__*/_regenerator["default"].mark(function _callee3(username, password, authCode) {
         var _this = this;
-
         var issuerUrl, issuer, codeChallenge, authUrl, noRedirects, authResponse, location, sessionId, returnUrl, cookies, xsrfCookie, xsrfToken, authCookies;
-        return _regenerator["default"].wrap(function _callee3$(_context3) {
-          while (1) {
-            switch (_context3.prev = _context3.next) {
-              case 0:
-                issuerUrl = "https://accounts.magister.net";
-                _context3.next = 3;
-                return _openidClient.Issuer.discover(issuerUrl);
-
-              case 3:
-                issuer = _context3.sent;
-                codeChallenge = _openidClient.generators.codeChallenge(this.codeVerifier);
-                this.client = new issuer.Client({
-                  authority: issuerUrl,
-                  client_id: "M6LOAPP",
-                  redirect_uris: ["m6loapp://oauth2redirect/"],
-                  response_types: ["code id_token"],
-                  id_token_signed_response_alg: "RS256",
-                  token_endpoint_auth_method: "none"
-                });
-                this.client[_openidClient.custom.clock_tolerance] = 5;
-                authUrl = this.client.authorizationUrl({
-                  scope: "openid profile offline_access",
-                  code_challenge: codeChallenge,
-                  code_challenge_method: "S256",
-                  acr_values: "tenant:".concat(this.tenant),
-                  client_id: "M6LOAPP",
-                  state: this.state,
-                  nonce: this.nonce,
-                  prompt: "select_account"
-                });
-                noRedirects = {
-                  redirect: "manual",
-                  follow: 0
-                };
-                _context3.next = 11;
-                return (0, _nodeFetch["default"])(authUrl, noRedirects).then(function (response) {
-                  return (0, _nodeFetch["default"])(response.headers.get("location"), noRedirects);
-                });
-
-              case 11:
-                authResponse = _context3.sent;
-                location = authResponse.headers.get("location");
-                sessionId = (0, _common.extractQueryParameter)("".concat(issuerUrl).concat(location), "sessionId");
-                returnUrl = (0, _common.extractQueryParameter)("".concat(issuerUrl).concat(location), "returnUrl");
-                cookies = authResponse.headers.raw()["set-cookie"];
-                xsrfCookie = cookies.filter(function (cookie) {
-                  return cookie.split("=")[0] === "XSRF-TOKEN";
-                })[0];
-                xsrfToken = xsrfCookie.split("=")[1].split(";")[0];
-                _context3.next = 20;
-                return (0, _nodeFetch["default"])("".concat(issuerUrl, "/challenges/username"), {
-                  method: "post",
-                  body: JSON.stringify({
-                    authCode: authCode,
-                    sessionId: sessionId,
-                    returnUrl: returnUrl,
-                    username: username
-                  }),
-                  headers: {
-                    "Content-Type": "application/json",
-                    cookie: authResponse.headers.raw()["set-cookie"],
-                    "X-XSRF-TOKEN": xsrfToken
-                  }
-                }).then(this.validate);
-
-              case 20:
-                _context3.next = 22;
-                return (0, _nodeFetch["default"])("".concat(issuerUrl, "/challenges/password"), {
-                  method: "post",
-                  body: JSON.stringify({
-                    authCode: authCode,
-                    sessionId: sessionId,
-                    returnUrl: returnUrl,
-                    password: password
-                  }),
-                  headers: {
-                    "Content-Type": "application/json",
-                    cookie: authResponse.headers.raw()["set-cookie"],
-                    "X-XSRF-TOKEN": xsrfToken
-                  }
-                }).then( /*#__PURE__*/function () {
-                  var _ref = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee2(response) {
-                    return _regenerator["default"].wrap(function _callee2$(_context2) {
-                      while (1) {
-                        switch (_context2.prev = _context2.next) {
-                          case 0:
-                            _context2.next = 2;
-                            return _this.validate(response);
-
-                          case 2:
-                            return _context2.abrupt("return", response.headers.raw()["set-cookie"]);
-
-                          case 3:
-                          case "end":
-                            return _context2.stop();
-                        }
-                      }
-                    }, _callee2);
-                  }));
-
-                  return function (_x5) {
-                    return _ref.apply(this, arguments);
-                  };
-                }());
-
-              case 22:
-                authCookies = _context3.sent;
-                return _context3.abrupt("return", (0, _nodeFetch["default"])("".concat(issuerUrl).concat(returnUrl), {
-                  redirect: "manual",
-                  follow: 0,
-                  headers: {
-                    cookie: authCookies
-                  }
-                }).then(function (response) {
-                  var url = response.headers.get("location");
-                  return url.split("#code=")[1].split("&")[0];
+        return _regenerator["default"].wrap(function (_context3) {
+          while (1) switch (_context3.prev = _context3.next) {
+            case 0:
+              issuerUrl = "https://accounts.magister.net";
+              _context3.next = 1;
+              return _openidClient.Issuer.discover(issuerUrl);
+            case 1:
+              issuer = _context3.sent;
+              codeChallenge = _openidClient.generators.codeChallenge(this.codeVerifier);
+              this.client = new issuer.Client({
+                authority: issuerUrl,
+                client_id: "M6LOAPP",
+                redirect_uris: ["m6loapp://oauth2redirect/"],
+                response_types: ["code id_token"],
+                id_token_signed_response_alg: "RS256",
+                token_endpoint_auth_method: "none"
+              });
+              this.client[_openidClient.custom.clock_tolerance] = 5;
+              authUrl = this.client.authorizationUrl({
+                scope: "openid profile offline_access",
+                code_challenge: codeChallenge,
+                code_challenge_method: "S256",
+                acr_values: "tenant:".concat(this.tenant),
+                client_id: "M6LOAPP",
+                state: this.state,
+                nonce: this.nonce,
+                prompt: "select_account"
+              });
+              noRedirects = {
+                redirect: "manual",
+                follow: 0
+              };
+              _context3.next = 2;
+              return (0, _nodeFetch["default"])(authUrl, noRedirects).then(function (response) {
+                return (0, _nodeFetch["default"])(response.headers.get("location"), noRedirects);
+              });
+            case 2:
+              authResponse = _context3.sent;
+              location = authResponse.headers.get("location");
+              sessionId = (0, _common.extractQueryParameter)("".concat(issuerUrl).concat(location), "sessionId");
+              returnUrl = (0, _common.extractQueryParameter)("".concat(issuerUrl).concat(location), "returnUrl");
+              cookies = authResponse.headers.raw()["set-cookie"];
+              xsrfCookie = cookies.filter(function (cookie) {
+                return cookie.split("=")[0] === "XSRF-TOKEN";
+              })[0];
+              xsrfToken = xsrfCookie.split("=")[1].split(";")[0];
+              _context3.next = 3;
+              return (0, _nodeFetch["default"])("".concat(issuerUrl, "/challenges/username"), {
+                method: "post",
+                body: JSON.stringify({
+                  authCode: authCode,
+                  sessionId: sessionId,
+                  returnUrl: returnUrl,
+                  username: username
+                }),
+                headers: {
+                  "Content-Type": "application/json",
+                  cookie: cookies.join('; '),
+                  "X-XSRF-TOKEN": xsrfToken
+                }
+              }).then(this.validate);
+            case 3:
+              _context3.next = 4;
+              return (0, _nodeFetch["default"])("".concat(issuerUrl, "/challenges/password"), {
+                method: "post",
+                body: JSON.stringify({
+                  authCode: authCode,
+                  sessionId: sessionId,
+                  returnUrl: returnUrl,
+                  password: password
+                }),
+                headers: {
+                  "Content-Type": "application/json",
+                  cookie: cookies.join('; '),
+                  "X-XSRF-TOKEN": xsrfToken
+                }
+              }).then(/*#__PURE__*/function () {
+                var _ref = (0, _asyncToGenerator2["default"])(/*#__PURE__*/_regenerator["default"].mark(function _callee2(response) {
+                  return _regenerator["default"].wrap(function (_context2) {
+                    while (1) switch (_context2.prev = _context2.next) {
+                      case 0:
+                        _context2.next = 1;
+                        return _this.validate(response);
+                      case 1:
+                        return _context2.abrupt("return", response.headers.raw()["set-cookie"]);
+                      case 2:
+                      case "end":
+                        return _context2.stop();
+                    }
+                  }, _callee2);
                 }));
-
-              case 24:
-              case "end":
-                return _context3.stop();
-            }
+                return function (_x5) {
+                  return _ref.apply(this, arguments);
+                };
+              }());
+            case 4:
+              authCookies = _context3.sent;
+              return _context3.abrupt("return", (0, _nodeFetch["default"])("".concat(issuerUrl).concat(returnUrl), {
+                redirect: "manual",
+                follow: 0,
+                headers: {
+                  cookie: [].concat((0, _toConsumableArray2["default"])(cookies), (0, _toConsumableArray2["default"])(authCookies)).join('; ')
+                }
+              }).then(function (response) {
+                var url = response.headers.get("location");
+                return url.split("#code=")[1].split("&")[0];
+              }));
+            case 5:
+            case "end":
+              return _context3.stop();
           }
         }, _callee3, this);
       }));
-
       function getCode(_x2, _x3, _x4) {
         return _getCode.apply(this, arguments);
       }
-
       return getCode;
     }()
   }]);
-  return AuthProvider;
 }();
-
-exports.AuthProvider = AuthProvider;

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -1,32 +1,23 @@
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.AuthManager = void 0;
-
 var _regenerator = _interopRequireDefault(require("@babel/runtime/regenerator"));
-
 var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
 var _authentication = require("./authentication");
-
 var _common = require("./utils/common");
-
-var AuthManager = /*#__PURE__*/function () {
+var AuthManager = exports.AuthManager = /*#__PURE__*/function () {
   function AuthManager(tenant, tokenSet) {
     (0, _classCallCheck2["default"])(this, AuthManager);
     this._authProvider = new _authentication.AuthProvider(tenant);
     this.tokenSet = tokenSet || {};
   }
-
-  (0, _createClass2["default"])(AuthManager, [{
+  return (0, _createClass2["default"])(AuthManager, [{
     key: "accessToken",
     get: function get() {
       return this.tokenSet.access_token;
@@ -49,108 +40,84 @@ var AuthManager = /*#__PURE__*/function () {
   }, {
     key: "checkExpiration",
     value: function () {
-      var _checkExpiration = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee() {
+      var _checkExpiration = (0, _asyncToGenerator2["default"])(/*#__PURE__*/_regenerator["default"].mark(function _callee() {
         var autoRefresh,
-            expired,
-            _args = arguments;
-        return _regenerator["default"].wrap(function _callee$(_context) {
-          while (1) {
-            switch (_context.prev = _context.next) {
-              case 0:
-                autoRefresh = _args.length > 0 && _args[0] !== undefined ? _args[0] : true;
-                expired = (0, _common.getTime)() > this.expiresAt;
-
-                if (!(expired && autoRefresh)) {
-                  _context.next = 5;
-                  break;
-                }
-
-                _context.next = 5;
-                return this.refresh();
-
-              case 5:
-                return _context.abrupt("return", expired);
-
-              case 6:
-              case "end":
-                return _context.stop();
-            }
+          expired,
+          _args = arguments;
+        return _regenerator["default"].wrap(function (_context) {
+          while (1) switch (_context.prev = _context.next) {
+            case 0:
+              autoRefresh = _args.length > 0 && _args[0] !== undefined ? _args[0] : true;
+              expired = (0, _common.getTime)() > this.expiresAt;
+              if (!(expired && autoRefresh)) {
+                _context.next = 1;
+                break;
+              }
+              _context.next = 1;
+              return this.refresh();
+            case 1:
+              return _context.abrupt("return", expired);
+            case 2:
+            case "end":
+              return _context.stop();
           }
         }, _callee, this);
       }));
-
       function checkExpiration() {
         return _checkExpiration.apply(this, arguments);
       }
-
       return checkExpiration;
     }()
   }, {
     key: "login",
     value: function () {
-      var _login = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee2(username, password, authCode) {
+      var _login = (0, _asyncToGenerator2["default"])(/*#__PURE__*/_regenerator["default"].mark(function _callee2(username, password, authCode) {
         var code;
-        return _regenerator["default"].wrap(function _callee2$(_context2) {
-          while (1) {
-            switch (_context2.prev = _context2.next) {
-              case 0:
-                _context2.next = 2;
-                return this._authProvider.getCode(username, password, authCode);
-
-              case 2:
-                code = _context2.sent;
-                _context2.next = 5;
-                return this._authProvider.getTokenSet(code);
-
-              case 5:
-                this.tokenSet = _context2.sent;
-                return _context2.abrupt("return", this.tokenSet);
-
-              case 7:
-              case "end":
-                return _context2.stop();
-            }
+        return _regenerator["default"].wrap(function (_context2) {
+          while (1) switch (_context2.prev = _context2.next) {
+            case 0:
+              _context2.next = 1;
+              return this._authProvider.getCode(username, password, authCode);
+            case 1:
+              code = _context2.sent;
+              _context2.next = 2;
+              return this._authProvider.getTokenSet(code);
+            case 2:
+              this.tokenSet = _context2.sent;
+              return _context2.abrupt("return", this.tokenSet);
+            case 3:
+            case "end":
+              return _context2.stop();
           }
         }, _callee2, this);
       }));
-
       function login(_x, _x2, _x3) {
         return _login.apply(this, arguments);
       }
-
       return login;
     }()
   }, {
     key: "refresh",
     value: function () {
-      var _refresh = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee3() {
-        return _regenerator["default"].wrap(function _callee3$(_context3) {
-          while (1) {
-            switch (_context3.prev = _context3.next) {
-              case 0:
-                _context3.next = 2;
-                return this._authProvider.refreshTokenSet(this.refreshToken);
-
-              case 2:
-                this.tokenSet = _context3.sent;
-                return _context3.abrupt("return", this.tokenSet);
-
-              case 4:
-              case "end":
-                return _context3.stop();
-            }
+      var _refresh = (0, _asyncToGenerator2["default"])(/*#__PURE__*/_regenerator["default"].mark(function _callee3() {
+        return _regenerator["default"].wrap(function (_context3) {
+          while (1) switch (_context3.prev = _context3.next) {
+            case 0:
+              _context3.next = 1;
+              return this._authProvider.refreshTokenSet(this.refreshToken);
+            case 1:
+              this.tokenSet = _context3.sent;
+              return _context3.abrupt("return", this.tokenSet);
+            case 2:
+            case "end":
+              return _context3.stop();
           }
         }, _callee3, this);
       }));
-
       function refresh() {
         return _refresh.apply(this, arguments);
       }
-
       return refresh;
     }()
   }]);
-  return AuthManager;
 }();
-
-exports.AuthManager = AuthManager;

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -5,12 +5,10 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.extractQueryParameter = extractQueryParameter;
 exports.getTime = getTime;
-
 function extractQueryParameter(url, parameter) {
   var parsedUrl = new URL(url);
   return parsedUrl.searchParams.get(parameter);
 }
-
 function getTime() {
   return Math.round(new Date().getTime() / 1000);
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "@babel/runtime": "^7.19.0",
     "dotenv": "^16.0.2",
     "node-fetch": "^2.6.7",
-    "openid-client": "^5.1.9"
+    "openid-client": "^3.8.4"
   }
 }

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -97,7 +97,7 @@ export class AuthProvider {
       }),
       headers: {
         "Content-Type": "application/json",
-        cookie: authResponse.headers.raw()["set-cookie"],
+        cookie: cookies.join('; '),
         "X-XSRF-TOKEN": xsrfToken
       }
     }).then(this.validate);
@@ -112,7 +112,7 @@ export class AuthProvider {
       }),
       headers: {
         "Content-Type": "application/json",
-        cookie: authResponse.headers.raw()["set-cookie"],
+        cookie: cookies.join('; '),
         "X-XSRF-TOKEN": xsrfToken
       }
     }).then(async response => {
@@ -124,7 +124,7 @@ export class AuthProvider {
       redirect: "manual",
       follow: 0,
       headers: {
-        cookie: authCookies
+        cookie: [...cookies, ...authCookies].join('; ')
       }
     }).then(response => {
       const url = response.headers.get("location");


### PR DESCRIPTION
Magister seemed to have made changes to the authentication flow, making both the response as well as the request cookies from the `${issuerUrl}/challenges/password` request necessary.

I've also reverted the version bump for the library `openid-client`, as it seems that newer versions require stricter configurations, that Magister obviously has not implemented. The newer versions require a issuing authority (iss) to be set, but it seems that key is missing from responses coming from Magister. This results in the error `RPError: iss missing from the response`. Reverting the version bump seems to be to easiest fix for this. 